### PR TITLE
Io's Landing Updates

### DIFF
--- a/Complete Zones/Ios Landing/Loot/heavyexo.xml
+++ b/Complete Zones/Ios Landing/Loot/heavyexo.xml
@@ -3,7 +3,7 @@
 		<loot name="LAW" itemID="1004" chance="100" quantity="3"></loot>
 		<loot name="Scrap Metal" itemID="2026" chance="100" quantity="8"></loot>
 		<loot name="Hand Grenade" itemID="1007" chance="100" quantity="9"></loot>
-		<loot name="Incendiary Grenade" itemID="1176" chance="100" quantity="4"></loot>
+		<loot name="Incendiary Grenade" itemID="1176" chance="100" quantity="6"></loot>
 	</normal>
 	<common chance="1" count="1">
 		<loot name="Weapon Powerup" itemID="128" chance="34" quantity="1"></loot>

--- a/Complete Zones/Ios Landing/Loot/heavyexo.xml
+++ b/Complete Zones/Ios Landing/Loot/heavyexo.xml
@@ -3,6 +3,7 @@
 		<loot name="LAW" itemID="1004" chance="100" quantity="3"></loot>
 		<loot name="Scrap Metal" itemID="2026" chance="100" quantity="8"></loot>
 		<loot name="Hand Grenade" itemID="1007" chance="100" quantity="9"></loot>
+		<loot name="Incendiary Grenade" itemID="1176" chance="100" quantity="4"></loot>
 	</normal>
 	<common chance="1" count="1">
 		<loot name="Weapon Powerup" itemID="128" chance="34" quantity="1"></loot>

--- a/Complete Zones/Ios Landing/Loot/veteranmarine.xml
+++ b/Complete Zones/Ios Landing/Loot/veteranmarine.xml
@@ -1,9 +1,6 @@
 <lootTable botID="154" name="Veteran Marine">
 	<normal>
 		<loot name="Marine Helmet" itemID="103" chance="95" quantity="1"></loot>
-		<loot name="Weapon Powerup" itemID="128" chance="2" quantity="1"></loot>
-		<loot name="Protection Powerup" itemID="138" chance="2" quantity="1"></loot>
-		<loot name="Speed Powerup" itemID="137" chance="2" quantity="1"></loot>
 	</normal>
 	<common chance="1" count="1">
 		<loot name="None" itemID="0" chance="95" quantity="1"></loot>

--- a/Complete Zones/Ios Landing/Loot/veteranripper.xml
+++ b/Complete Zones/Ios Landing/Loot/veteranripper.xml
@@ -1,9 +1,6 @@
 <lootTable botID="153" name="Veteran Ripper">
 	<normal>
 		<loot name="Ripper Helmet" itemID="106" chance="95" quantity="1"></loot>
-		<loot name="Weapon Powerup" itemID="128" chance="2" quantity="1"></loot>
-		<loot name="Protection Powerup" itemID="138" chance="2" quantity="1"></loot>
-		<loot name="Speed Powerup" itemID="137" chance="2" quantity="1"></loot>
 	</normal>
 	<common chance="1" count="1">
 		<loot name="None" itemID="0" chance="95" quantity="1"></loot>

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/Medic/Medic.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/Medic/Medic.cs
@@ -278,7 +278,8 @@ namespace InfServer.Script.GameType_Multi
             if (target._team != _team)
                 return false;
 
-            if (target._state.health == target._baseVehicle._type.Hitpoints)
+            //if (target._state.health == target._baseVehicle._type.Hitpoints)
+            if (target._state.health > Math.Floor(0.9* target._baseVehicle._type.Hitpoints))
                 return false;
 
             if (_arena.getTerrain(target._state.positionX, target._state.positionY).safety)

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
@@ -26,7 +26,7 @@ namespace InfServer.Script.GameType_Multi.Bots
 		public float runDist;               //The distance from the player where we run away!
 		public float fireDist;
 		public static ushort basevehicleID = 145;
-		public static ushort vetvehicleID = 152;
+		public static ushort vetvehicleID = 153;
 		public static ushort adeptvehicleID = 152;
 
 		///////////////////////////////////////////////////

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/BotHandler.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/BotHandler.cs
@@ -22,6 +22,7 @@ namespace InfServer.Script.GameType_Multi
         public Dictionary<ushort, Player> _medBotFollowTargets;
         public Dictionary<ushort, Player> _medBotHealTargets;
         public double hpMultiplier = 0.25;
+        public int bonusBots = 0;
         public int _lastHPChange;
 
         public Dictionary<string, Type> _botTypes;
@@ -31,13 +32,16 @@ namespace InfServer.Script.GameType_Multi
             if (_bots == null)
                 _bots = new List<Bot>();
 
+            // Bonus difficulty modifier by Cadenza
+            // new arena name syntax: "[Co-Op]<#> <DIFFICULTY>"
+            // examples: [Co-Op]3 Normal, [Co-Op]1 Hell
+            int d = 0, d_max = 9;
+            if(int.TryParse(_arena._name.Split(']')[1].Split(' ')[0], out d))
+                bonusBots = Math.Min(d_max,Math.Max(0,d));
+
             int extraBots = 0;
-
             if (_arena._name.EndsWith("Hell"))
-                extraBots = (int)(_arena.PlayerCount * 0.50);
-                
-
-            
+                extraBots = (int)((_arena.PlayerCount+bonusBots) * 0.50);
 
             if (spawnBots && _arena._bGameRunning)
             {
@@ -77,7 +81,7 @@ namespace InfServer.Script.GameType_Multi
                 {
                     int botcount = _bots.Where(b => ((b._type.Id == 131) || (b._type.Id == 151) || (b._type.Id == 154)) && b._team == _botTeam).Count();
                     int playercount = _team.ActivePlayerCount;
-                    int max = Convert.ToInt32((playercount * 1.25) + extraBots);
+                    int max = Convert.ToInt32((playercount+bonusBots)*1.25 + extraBots);
 
                     if (botcount < max) 
                     {
@@ -92,15 +96,12 @@ namespace InfServer.Script.GameType_Multi
                 {
                     int botcount = _bots.Where(b => ((b._type.Id == 145) || (b._type.Id == 152) || (b._type.Id == 153)) && b._team == _botTeam).Count();
                     int playercount = _team.ActivePlayerCount;
-                    int max = (int)((playercount * 0.25) + extraBots);
-
-                    if (max < 1)
-                        max = 1;
+                    int max = (int)((playercount+bonusBots+(extraBots>0?1:2))/(extraBots>0?2:3));
 
                     if (botcount < max)
                     {
                         int add = (max - botcount);
-                        _lastMarineWave = now;
+                        _lastRipperWave = now;
                         spawnRipperWave(_botTeam, _baseScript._coop._team, add);
                     }
                 }
@@ -300,13 +301,13 @@ namespace InfServer.Script.GameType_Multi
 
                         if (hpMultiplier != 0.0)
                         {
-                            if (_team.ActivePlayerCount <= 1)
+                            if (_team.ActivePlayerCount <= 1 && bonusBots == 0)
                             {
                                 heavy._state.health = Convert.ToInt16(heavy._type.Hitpoints);
                             }
                             else
                             {
-                                heavy._state.health = Convert.ToInt16(heavy._type.Hitpoints + (heavy._type.Hitpoints * (_team.ActivePlayerCount * hpMultiplier)));
+                                heavy._state.health = Convert.ToInt16(heavy._type.Hitpoints + (heavy._type.Hitpoints * (_team.ActivePlayerCount+bonusBots) * hpMultiplier));
                             }
                            
                         }
@@ -341,13 +342,13 @@ namespace InfServer.Script.GameType_Multi
 
                         if (hpMultiplier != 0.0)
                         {
-                            if (_team.ActivePlayerCount <= 1)
+                            if (_team.ActivePlayerCount <= 1 && bonusBots == 0)
                             {
                                 elitemarine._state.health = Convert.ToInt16(elitemarine._type.Hitpoints);
                             }
                             else
                             {
-                                elitemarine._state.health = Convert.ToInt16(elitemarine._type.Hitpoints + (elitemarine._type.Hitpoints * (_team.ActivePlayerCount * hpMultiplier)));
+                                elitemarine._state.health = Convert.ToInt16(elitemarine._type.Hitpoints + (elitemarine._type.Hitpoints * (_team.ActivePlayerCount+bonusBots) * hpMultiplier));
                             }
 
                         }
@@ -384,13 +385,13 @@ namespace InfServer.Script.GameType_Multi
                         
                         if (hpMultiplier != 0.0)
                         {
-                            if (_team.ActivePlayerCount <= 1)
+                            if (_team.ActivePlayerCount <= 1 && bonusBots == 0)
                             {
                                 exo._state.health = Convert.ToInt16(exo._type.Hitpoints);
                             }
                             else
                             {
-                                exo._state.health = Convert.ToInt16(exo._type.Hitpoints + (exo._type.Hitpoints * (_team.ActivePlayerCount * hpMultiplier)));
+                                exo._state.health = Convert.ToInt16(exo._type.Hitpoints + (exo._type.Hitpoints * (_team.ActivePlayerCount+bonusBots) * hpMultiplier));
                             }
 
                         }
@@ -426,13 +427,13 @@ namespace InfServer.Script.GameType_Multi
 
                         if (hpMultiplier != 0.0)
                         {
-                            if (_team.ActivePlayerCount <= 1)
+                            if (_team.ActivePlayerCount <= 1 && bonusBots == 0)
                             {
                                 exo._state.health = Convert.ToInt16(exo._type.Hitpoints);
                             }
                             else
                             {
-                                exo._state.health = Convert.ToInt16(exo._type.Hitpoints + (exo._type.Hitpoints * (_team.ActivePlayerCount * hpMultiplier)));
+                                exo._state.health = Convert.ToInt16(exo._type.Hitpoints + (exo._type.Hitpoints * (_team.ActivePlayerCount+bonusBots) * hpMultiplier));
                             }
 
                         }

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
@@ -386,16 +386,30 @@ namespace InfServer.Script.GameType_Multi
                 case 10:
                     _arena.sendArenaMessage(string.Format("{0} is on fire!", killer._alias), 17);
                     break;
+                case 28:
+                    {
+                        if(killer.getInventoryAmount(1325) > 0)
+                            killer.sendMessage(0, "Remember to use your existing Pavelow summon before you get another!");
+                    }
+                    break;
                 case 30:
                     {
                         _arena.sendArenaMessage(string.Format("Someone kill {0}!", killer._alias), 18);
-                        killer.sendMessage(0, "You've been awarded a Pavelow for your efforts, Check your inventory and call it in!");
+                        if(killer.getInventoryAmount(1325) == 0)
+                            killer.sendMessage(0, "You've been awarded a Pavelow for your efforts - check your inventory and call it in!");
                         killer.inventoryModify(1325, 1);
+                    }
+                    break;
+                case 38:
+                    {
+                        if(killer.getInventoryAmount(1476) > 0)
+                            killer.sendMessage(0, "Remember to use your existing Juggernaut summon before you get another!");
                     }
                     break;
                 case 40:
                     {
-                        killer.sendMessage(0, "You've been awarded a Juggernaut for your efforts, Check your inventory and call it in!");
+                    	if(killer.getInventoryAmount(1476) == 0)
+                            killer.sendMessage(0, "You've been awarded a Juggernaut for your efforts - check your inventory and call it in!");
                         killer.inventoryModify(1476, 1);
                     }
                     break;


### PR DESCRIPTION
Various QOL updates and bugfix for Io's Landing:
* AI Ripper spawn now properly decoupled from AI Marine spawn
* AI spawn rate in co-op mode now player adjustable
* medic heal logic adjusted to reduce energy waste
* use-it-or-lose-it reminders for killstreak grenades
* veteran AI rippers restored
* rebalanced item drops for non-LAW classes
* redundant items removed from drop tables

_(changes already applied to live server)_