### PR TITLE
 Io's Landing 231201 patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Complete Zones/Ios Landing/assets/ioslanding.nws
+++ b/Complete Zones/Ios Landing/assets/ioslanding.nws
@@ -48,6 +48,14 @@ Skirmish Extreme combines the classic Skirmish feel with some great new features
 
 ~B~2Zone Updates~B
 
+[=~b~511/30/2023~2~B=]
+~b~4-C~2~B
+~4
+1. Extended LAW fire rate adjustments to Elite Marine and Elite Heavy (0% against JT, 100% against mechs)
+2. Implemented measures to encourage flagging by discouraging farming: For each non-boss bot kill before 11/39 captured objectives, bty/pt reward is reduced by 10% (with floor of 1 at 1/39); cash/exp rewards remain unchanged
+3. Reduced log messages on the backend (not a visible change to players)
+
+
 [=~b~511/29/2023~2~B=]
 ~b~4-C~2~B
 ~4

--- a/Complete Zones/Ios Landing/assets/ioslanding.nws
+++ b/Complete Zones/Ios Landing/assets/ioslanding.nws
@@ -48,7 +48,7 @@ Skirmish Extreme combines the classic Skirmish feel with some great new features
 
 ~B~2Zone Updates~B
 
-[=~b~511/30/2023~2~B=]
+[=~b~512/01/2023~2~B=]
 ~b~4-C~2~B
 ~4
 1. Extended LAW fire rate adjustments to Elite Marine and Elite Heavy (0% against JT, 100% against mechs)

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteHeavy/Actions/Actions.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteHeavy/Actions/Actions.cs
@@ -72,8 +72,8 @@ namespace InfServer.Script.GameType_Multi
                             string LAW_vName = "";
                             bool is_LAW_target = false;
 
-                            if(target._occupiedVehicle != null){
-                                LAW_vName = target._occupiedVehicle._type.Name;
+                            if(_target._occupiedVehicle != null){
+                                LAW_vName = _target._occupiedVehicle._type.Name;
                                 is_LAW_target = (LAW_vName=="Slick" || LAW_vName=="Light Attack ExoSuit");
                             }
 

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteHeavy/Actions/Actions.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteHeavy/Actions/Actions.cs
@@ -68,10 +68,19 @@ namespace InfServer.Script.GameType_Multi
                         //Should we be firing our rifle?
                         if (distance <= fireDist && distance > sgDist)
                         {
-                            if (_weapon.ItemID != AssetManager.Manager.getItemByID(_type.InventoryItems[0]).id)
-                            _weapon.equip(AssetManager.Manager.getItemByID(_type.InventoryItems[0]));
 
-                            if (_target._occupiedVehicle != null && _target._occupiedVehicle._type.ClassId > 0 && _lawQuantity >= 1)
+                            string LAW_vName = "";
+                            bool is_LAW_target = false;
+
+                            if(target._occupiedVehicle != null){
+                                LAW_vName = target._occupiedVehicle._type.Name;
+                                is_LAW_target = (LAW_vName=="Slick" || LAW_vName=="Light Attack ExoSuit");
+                            }
+
+                            if (_weapon.ItemID != AssetManager.Manager.getItemByID(_type.InventoryItems[0]).id)
+                                _weapon.equip(AssetManager.Manager.getItemByID(_type.InventoryItems[0]));
+
+                            if (is_LAW_target && _lawQuantity >= 1)
                                 _weapon.equip(_arena._server._assets.getItemByID(1004));
 
                             if (_weapon.ableToFire())
@@ -81,7 +90,7 @@ namespace InfServer.Script.GameType_Multi
 
                                 if (_weapon.isAimed(aimResult))
                                 {
-                                    if (_target._occupiedVehicle != null && _target._occupiedVehicle._type.ClassId > 0 && _lawQuantity >= 1)
+                                    if (is_LAW_target && _lawQuantity >= 1)
                                     {
                                         _lawQuantity--;
                                         _movement.freezeMovement(3000);

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteMarine/Actions/Actions.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteMarine/Actions/Actions.cs
@@ -70,8 +70,8 @@ namespace InfServer.Script.GameType_Multi
                             string LAW_vName = "";
                             bool is_LAW_target = false;
 
-                            if(target._occupiedVehicle != null){
-                                LAW_vName = target._occupiedVehicle._type.Name;
+                            if(_target._occupiedVehicle != null){
+                                LAW_vName = _target._occupiedVehicle._type.Name;
                                 is_LAW_target = (LAW_vName=="Slick" || LAW_vName=="Light Attack ExoSuit");
                             }
 

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteMarine/Actions/Actions.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/EliteMarine/Actions/Actions.cs
@@ -66,7 +66,16 @@ namespace InfServer.Script.GameType_Multi
                         //Should we be firing our rifle?
                         if (distance <= fireDist && distance > sgDist)
                         {
-                            if (_target._occupiedVehicle != null && _target._occupiedVehicle._type.ClassId > 0 && _lawQuantity >= 1)
+
+                            string LAW_vName = "";
+                            bool is_LAW_target = false;
+
+                            if(target._occupiedVehicle != null){
+                                LAW_vName = target._occupiedVehicle._type.Name;
+                                is_LAW_target = (LAW_vName=="Slick" || LAW_vName=="Light Attack ExoSuit");
+                            }
+
+                            if (is_LAW_target && _lawQuantity >= 1)
                                 _weapon.equip(_arena._server._assets.getItemByID(1004));
                             else
                                 _weapon.equip(AssetManager.Manager.getItemByID(_type.InventoryItems[0]));
@@ -77,7 +86,7 @@ namespace InfServer.Script.GameType_Multi
 
                                 if (_weapon.isAimed(aimResult))
                                 {
-                                    if (_target._occupiedVehicle != null && _target._occupiedVehicle._type.ClassId > 0 && _lawQuantity >= 1)
+                                    if (is_LAW_target && _lawQuantity >= 1)
                                     {
                                         _lawQuantity--;
                                         _movement.freezeMovement(3000);

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/MarineV2/MarineV2.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/MarineV2/MarineV2.cs
@@ -32,10 +32,10 @@ namespace InfServer.Script.GameType_Multi.Bots
 		WeaponController.WeaponSettings settings;
 
 		// LAW fire rate adjustment
-		public string LAW_target_group1 = "Slick || Light Attack ExoSuit";
-		public string LAW_target_group2 = "Deathboard || Drop Pack";
-		public double LAW_misfire_rate1 = 0.6; // failure rate against mechs
-		public double LAW_misfire_rate2 = 0.9; // failure rate against non-mechs
+		public const string LAW_target_group1 = "Slick || Light Attack ExoSuit";
+		public const string LAW_target_group2 = "Deathboard || Drop Pack";
+		public const double LAW_misfire_rate1 = 0.6; // failure rate against mechs
+		public const double LAW_misfire_rate2 = 0.9; // failure rate against non-mechs
 
 		// workaround for "infinite clip size"
 		//public int clip_size = 45;

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/MarineV2/MarineV2.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/MarineV2/MarineV2.cs
@@ -32,13 +32,10 @@ namespace InfServer.Script.GameType_Multi.Bots
 		WeaponController.WeaponSettings settings;
 
 		// LAW fire rate adjustment
-		public bool law_target;
-		public bool weapon_misfired;
-		public string vname;
-		public string mechs = "Slick || Light Attack ExoSuit";
-		public string jumpt = "Deathboard || Drop Pack";
-		public double law_misfire_rate1 = 0.6; // against mechs
-		public double law_misfire_rate2 = 0.9; // against non-mechs
+		public string LAW_target_group1 = "Slick || Light Attack ExoSuit";
+		public string LAW_target_group2 = "Deathboard || Drop Pack";
+		public double LAW_misfire_rate1 = 0.6; // failure rate against mechs
+		public double LAW_misfire_rate2 = 0.9; // failure rate against non-mechs
 
 		// workaround for "infinite clip size"
 		//public int clip_size = 45;
@@ -115,14 +112,19 @@ namespace InfServer.Script.GameType_Multi.Bots
 					else
 					steering.steerDelegate = steerForAttack;
 
-					law_target = false;
+					string LAW_vName = "";
+					bool is_LAW_group1 = false;
+					bool is_LAW_group2 = false;
+					bool is_LAW_target = false;
 
 					if(target._occupiedVehicle != null){
-						vname = target._occupiedVehicle._type.Name;
-						law_target = (mechs.Contains(vname) || jumpt.Contains(vname));
+						LAW_vName = target._occupiedVehicle._type.Name;
+						is_LAW_group1 = LAW_target_group1.Contains(LAW_vName);
+						is_LAW_group2 = LAW_target_group2.Contains(LAW_vName);
+						is_LAW_target = (is_LAW_group1 || is_LAW_group2);
 					}
 
-					if (law_target && _lawQuantity >= 1)
+					if (is_LAW_target && _lawQuantity >= 1)
 						_weapon.equip(_arena._server._assets.getItemByID(1004));
 					else
 						_weapon.equip(AssetManager.Manager.getItemByID(_type.InventoryItems[0]));
@@ -135,25 +137,23 @@ namespace InfServer.Script.GameType_Multi.Bots
 						if (_weapon.isAimed(aimResult))
 						{
 
-							weapon_misfired = false;
+							bool LAW_misfired = false;
 
-							if (law_target && _lawQuantity >= 1)
+							if (is_LAW_target && _lawQuantity >= 1)
 							{
 								_lawQuantity--;
 								_movement.freezeMovement(3000);
 
-								bool is_mech = (target._occupiedVehicle._type.Name=="Slick" || target._occupiedVehicle._type.Name=="Light Attack ExoSuit");
-
 								// roll the dice
 								Random unlucky = new Random();
 								double roll = unlucky.NextDouble();
-								double rate = mechs.Contains(vname) ? law_misfire_rate1 : law_misfire_rate2;
-								weapon_misfired = roll < rate;
-								//Log.write(TLog.Warning, String.Format("[MarineV2] LAW target {0} / roll {1} / rate {2}", vname, roll, rate));
+								double rate = is_LAW_group1 ? LAW_misfire_rate1 : LAW_misfire_rate2;
+								LAW_misfired = roll < rate;
+								//Log.write(TLog.Warning, String.Format("[MarineV2] LAW target {0} / roll {1} / rate {2}", LAW_vName, roll, rate));
 
 							}
 
-							if(!weapon_misfired){
+							if(!LAW_misfired){
 								_itemUseID = _weapon.ItemID;
 								_weapon.shotFired();
 							}

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
@@ -32,10 +32,10 @@ namespace InfServer.Script.GameType_Multi.Bots
 		WeaponController.WeaponSettings settings;
 
 		// LAW fire rate adjustment
-		public string LAW_target_group1 = "Slick || Light Attack ExoSuit";
-		public string LAW_target_group2 = "Deathboard || Drop Pack";
-		public double LAW_misfire_rate1 = 0.2; // failure rate against mechs
-		public double LAW_misfire_rate2 = 0.8; // failure rate against non-mechs
+		public const string LAW_target_group1 = "Slick || Light Attack ExoSuit";
+		public const string LAW_target_group2 = "Deathboard || Drop Pack";
+		public const double LAW_misfire_rate1 = 0.2; // failure rate against mechs
+		public const double LAW_misfire_rate2 = 0.8; // failure rate against non-mechs
 
 		// workaround for "infinite clip size"
 		//public int clip_size = 45;

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/RipperV2/RipperV2.cs
@@ -32,13 +32,10 @@ namespace InfServer.Script.GameType_Multi.Bots
 		WeaponController.WeaponSettings settings;
 
 		// LAW fire rate adjustment
-		public bool law_target;
-		public bool weapon_misfired;
-		public string vname;
-		public string mechs = "Slick || Light Attack ExoSuit";
-		public string jumpt = "Deathboard || Drop Pack";
-		public double law_misfire_rate1 = 0.2; // failure rate against mechs
-		public double law_misfire_rate2 = 0.8; // failure rate against non-mechs
+		public string LAW_target_group1 = "Slick || Light Attack ExoSuit";
+		public string LAW_target_group2 = "Deathboard || Drop Pack";
+		public double LAW_misfire_rate1 = 0.2; // failure rate against mechs
+		public double LAW_misfire_rate2 = 0.8; // failure rate against non-mechs
 
 		// workaround for "infinite clip size"
 		//public int clip_size = 45;
@@ -57,10 +54,10 @@ namespace InfServer.Script.GameType_Multi.Bots
 			: base(type, state, arena)
 		{
 			//bOverriddenPoll = true;
-			fireDist = 6.9f;
 			farDist = 3.4f; 
 			shortDist = 1.2f; 
 			runDist = 0.2f;
+			fireDist = 6.9f;
 
 			if (type.InventoryItems[0] != 0)
 				_weapon.equip(AssetManager.Manager.getItemByID(type.InventoryItems[0]));
@@ -123,15 +120,19 @@ namespace InfServer.Script.GameType_Multi.Bots
 							return Vector3.Zero;
 						};
 
-					vname = "";
-					law_target = false;
+					string LAW_vName = "";
+					bool is_LAW_group1 = false;
+					bool is_LAW_group2 = false;
+					bool is_LAW_target = false;
 
 					if(target._occupiedVehicle != null){
-						vname = target._occupiedVehicle._type.Name;
-						law_target = (mechs.Contains(vname) || jumpt.Contains(vname));
+						LAW_vName = target._occupiedVehicle._type.Name;
+						is_LAW_group1 = LAW_target_group1.Contains(LAW_vName);
+						is_LAW_group2 = LAW_target_group2.Contains(LAW_vName);
+						is_LAW_target = (is_LAW_group1 || is_LAW_group2);
 					}
 
-					if (law_target && _lawQuantity >= 1)
+					if (is_LAW_target && _lawQuantity >= 1)
 						_weapon.equip(_arena._server._assets.getItemByID(1004));
 					else
 						_weapon.equip(AssetManager.Manager.getItemByID(_type.InventoryItems[0]));
@@ -149,9 +150,9 @@ namespace InfServer.Script.GameType_Multi.Bots
 						if (_weapon.isAimed(aimResult))
 						{
 
-							weapon_misfired = false;
+							bool LAW_misfired = false;
 
-							if (law_target && _lawQuantity >= 1)
+							if (is_LAW_target && _lawQuantity >= 1)
 							{
 								_lawQuantity--;
 								_movement.freezeMovement(3000);
@@ -159,13 +160,13 @@ namespace InfServer.Script.GameType_Multi.Bots
 								// roll the dice
 								Random unlucky = new Random();
 								double roll = unlucky.NextDouble();
-								double rate = mechs.Contains(vname) ? law_misfire_rate1 : law_misfire_rate2;
-								weapon_misfired = roll < rate;
-								//Log.write(TLog.Warning, String.Format("[RipperV2] LAW target {0} / roll {1} / rate {2}", vname, roll, rate));
+								double rate = is_LAW_group1 ? LAW_misfire_rate1 : LAW_misfire_rate2;
+								LAW_misfired = roll < rate;
+								//Log.write(TLog.Warning, String.Format("[RipperV2] LAW target {0} / roll {1} / rate {2}", LAW_vName, roll, rate));
 
 							}
 
-							if(!weapon_misfired){
+							if(!LAW_misfired){
 								_itemUseID = _weapon.ItemID;
 								_weapon.shotFired();
 							}

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Logic/Loot.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Logic/Loot.cs
@@ -59,7 +59,7 @@ namespace InfServer.Script.GameType_Multi
 
                 if (lootTable == null)
                 {
-                    Log.write("Could not find loot table for bot id {0}", dead._type.Id);
+                    Log.write(TLog.Warning, "Could not find loot table for bot id {0}", dead._type.Id);
                     return;
                 }
 
@@ -101,29 +101,29 @@ namespace InfServer.Script.GameType_Multi
                 List<LootInfo> potentialLoot = new List<LootInfo>();
                 foreach (Player player in players)
                 {
-                    Log.write("Trying loot drop for {0}", player._alias);
+                    //Log.write("Trying loot drop for {0}", player._alias);
                     weightRoll = _rand.Next(0, total);
 
-                    Log.write("Category Weight Roll: {0}", weightRoll);
+                    //Log.write("Category Weight Roll: {0}", weightRoll);
 
                     if (weightRoll.IsWithin(commonRange.min, commonRange.max))
                     {
-                        Log.write("selected commmon loot list");
+                        //Log.write("selected commmon loot list");
                         potentialLoot = lootTable.commonLoot;
                     }
                     else if (weightRoll.IsWithin(uncommonRange.min, uncommonRange.max))
                     {
-                        Log.write("selected uncommon loot list");
+                        //Log.write("selected uncommon loot list");
                         potentialLoot = lootTable.uncommonLoot;
                     }
                     else if (weightRoll.IsWithin(setRange.min, setRange.max))
                     {
-                        Log.write("selected set loot list");
+                        //Log.write("selected set loot list");
                         potentialLoot = lootTable.setLoot;
                     }
                     else if (weightRoll.IsWithin(rareRange.min, rareRange.max))
                     {
-                        Log.write("selected rare loot list");
+                        //Log.write("selected rare loot list");
                         potentialLoot = lootTable.rareLoot;
                     }
                     else
@@ -131,7 +131,7 @@ namespace InfServer.Script.GameType_Multi
                         //No loot for this guy :(
                         if (potentialLoot.Count == 0)
                         {
-                            Log.write("no loot list selected");
+                            //Log.write("no loot list selected");
                             continue;
                         }
 
@@ -151,7 +151,7 @@ namespace InfServer.Script.GameType_Multi
                     }
 
                     weightRoll = _rand.Next(0, totalLootProbability);
-                    Log.write("Item Weight Roll: {0}", weightRoll);
+                    //Log.write("Item Weight Roll: {0}", weightRoll);
                     LootInfo drop = lootRanges.FirstOrDefault(rng => weightRoll.IsWithin(rng.Key.min, rng.Key.max)).Value;
 
                     //Better luck next time!
@@ -180,7 +180,7 @@ namespace InfServer.Script.GameType_Multi
 
                 if (lootTable == null)
                 {
-                    Log.write("Could not find player loot table");
+                    Log.write(TLog.Warning, "Could not find player loot table");
                     return;
                 }
 
@@ -222,29 +222,29 @@ namespace InfServer.Script.GameType_Multi
                 List<LootInfo> potentialLoot = new List<LootInfo>();
                 foreach (Player player in players)
                 {
-                    Log.write("Trying loot drop for {0}", player._alias);
+                    //Log.write("Trying loot drop for {0}", player._alias);
                     weightRoll = _rand.Next(0, total);
 
-                    Log.write("Category Weight Roll: {0}", weightRoll);
+                    //Log.write("Category Weight Roll: {0}", weightRoll);
 
                     if (weightRoll.IsWithin(commonRange.min, commonRange.max))
                     {
-                        Log.write("selected commmon loot list");
+                        //Log.write("selected commmon loot list");
                         potentialLoot = lootTable.commonLoot;
                     }
                     else if (weightRoll.IsWithin(uncommonRange.min, uncommonRange.max))
                     {
-                        Log.write("selected uncommon loot list");
+                        //Log.write("selected uncommon loot list");
                         potentialLoot = lootTable.uncommonLoot;
                     }
                     else if (weightRoll.IsWithin(setRange.min, setRange.max))
                     {
-                        Log.write("selected set loot list");
+                        //Log.write("selected set loot list");
                         potentialLoot = lootTable.setLoot;
                     }
                     else if (weightRoll.IsWithin(rareRange.min, rareRange.max))
                     {
-                        Log.write("selected rare loot list");
+                        //Log.write("selected rare loot list");
                         potentialLoot = lootTable.rareLoot;
                     }
                     else
@@ -252,7 +252,7 @@ namespace InfServer.Script.GameType_Multi
                         //No loot for this guy :(
                         if (potentialLoot.Count == 0)
                         {
-                            Log.write("no loot list selected");
+                            //Log.write("no loot list selected");
                             continue;
                         }
 
@@ -272,7 +272,7 @@ namespace InfServer.Script.GameType_Multi
                     }
 
                     weightRoll = _rand.Next(0, totalLootProbability);
-                    Log.write("Item Weight Roll: {0}", weightRoll);
+                    //Log.write("Item Weight Roll: {0}", weightRoll);
                     LootInfo drop = lootRanges.FirstOrDefault(rng => weightRoll.IsWithin(rng.Key.min, rng.Key.max)).Value;
 
                     //Better luck next time!

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Logic/Rewards.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Logic/Rewards.cs
@@ -169,7 +169,7 @@ namespace InfServer.Script.GameType_Multi
         /// <summary>
         /// Calculates and rewards a players for a bot kill
         /// </summary>
-        static public void calculateBotKillRewards(Bot victim, Player killer, Settings.GameTypes gameType)
+        static public void calculateBotKillRewards(Bot victim, Player killer, Settings.GameTypes gameType, int flags)
         {
             CfgInfo cfg = killer._server._zoneConfig;
             int killerCash = 0;
@@ -177,7 +177,7 @@ namespace InfServer.Script.GameType_Multi
             int killerPoints = 0;
             int killerBounty = 0;
             int victimBounty = 0;
-            int killerBountyIncrease = 0;
+            //int killerBountyIncrease = 0;
 
             BotSettings settings = victim.Settings();
             if (settings != null)
@@ -193,7 +193,7 @@ namespace InfServer.Script.GameType_Multi
                 killerCash = Convert.ToInt32((settings.Cash) + (killerBounty * Settings.c_cashMultiplier));
                 killerExp = Convert.ToInt32((settings.Experience) + (killerBounty * Settings.c_expMultiplier));
                 victimBounty = settings.Bounty;
-                killerBountyIncrease = 0;
+                //killerBountyIncrease = 0;
 
             }
             else
@@ -209,7 +209,18 @@ namespace InfServer.Script.GameType_Multi
                 killerCash = Convert.ToInt32(((int)cfg.bot.cashKillReward) + (killerBounty * Settings.c_cashMultiplier));
                 killerExp = Convert.ToInt32(((int)cfg.bot.expKillReward) + (killerBounty * Settings.c_expMultiplier));
                 victimBounty = (int)cfg.bot.fixedBountyToKiller;
-                killerBountyIncrease = 0;
+                //killerBountyIncrease = 0;
+            }
+
+            if(victimBounty<200 && flags<11){
+                if(flags>1){
+                    double antifarm_multiplier = 0.10 * (flags-1);
+                    killerPoints = Convert.ToInt32(killerPoints * antifarm_multiplier);
+                    victimBounty = Convert.ToInt32(victimBounty * antifarm_multiplier);
+                }else{
+                    killerPoints = 1;
+                    victimBounty = 1;
+                }
             }
 
             //Update his stats
@@ -217,7 +228,8 @@ namespace InfServer.Script.GameType_Multi
             killer.Experience += killerExp;
             killer.KillPoints += killerPoints;
             //killer.Bounty += killerBounty;
-            killer.Bounty += (killerBountyIncrease + victimBounty);
+            //killer.Bounty += (killerBountyIncrease + victimBounty);
+            killer.Bounty += victimBounty;
 
             //Inform the killer..
             killer.triggerMessage(1, 500,

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
@@ -1187,7 +1187,12 @@ namespace InfServer.Script.GameType_Multi
                 Helpers.Vehicle_RouteDeath(_arena.Players, killer, dead, null);
                 if (killer != null && dead._team != killer._team)
                 {//Don't allow rewards for team kills
-                    Rewards.calculateBotKillRewards(dead, killer, _gameType);
+
+                    // pass # of captured objectives (anti-farm)
+                    Team _team = _arena.getTeamByName("Titan Militia");
+                    int flags = _arena._flags.Values.Where(f => f.team == _team).Count();
+
+                    Rewards.calculateBotKillRewards(dead, killer, _gameType, flags);
                 }
 
                 killer.Kills++;

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
@@ -106,8 +106,8 @@ namespace InfServer.Script.GameType_Multi
                 _gameType = Settings.GameTypes.Coop;
             else if (_arena._name.Equals("[PvP] Royale"))
                 _gameType = Settings.GameTypes.Royale;
-            else if (_arena._name.ToLower().StartsWith("[rts]"))
-                _gameType = Settings.GameTypes.RTS;
+            //else if (_arena._name.ToLower().StartsWith("[rts]"))
+            //    _gameType = Settings.GameTypes.RTS;
             else
             {
                 Team team1 = _arena.getTeamByName("Titan Militia");


### PR DESCRIPTION
* Extended LAW fire rate adjustments to Elite Marine and Elite Heavy (0% against JT, 100% against mechs)
* Implemented measures to encourage flagging by discouraging farming: For each non-boss bot kill before 11/39 captured objectives, bty/pt reward is reduced by 10% (with floor of 1 at 1/39); cash/exp rewards remain unchanged
* Reduced log messages on the backend (not a visible change to players)