### PR TITLE
Io's Landing 231212 patch

### DIFF
--- a/Complete Zones/Ios Landing/assets/ioslanding.nws
+++ b/Complete Zones/Ios Landing/assets/ioslanding.nws
@@ -48,6 +48,13 @@ Skirmish Extreme combines the classic Skirmish feel with some great new features
 
 ~B~2Zone Updates~B
 
+[=~b~512/12/2023~2~B=]
+~b~4-C~2~B
+~4
+1. Time until next game increased to 30 seconds if previous round was a full play-through (victory or buzzer).
+2. Fixed the infamous medic no-follow bug: the medic bot will now continue to follow players when they continue into a subsequent game. No more rejoins necessary.
+
+
 [=~b~512/11/2023~2~B=]
 ~b~4-C~2~B
 ~4

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/Medic/Medic.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Bots/Medic/Medic.cs
@@ -102,6 +102,10 @@ namespace InfServer.Script.GameType_Multi
             }
             int now = Environment.TickCount;
 
+            // key check
+            if(!_game._medBotHealTargets.ContainsKey(_id)) _game._medBotHealTargets.Add(_id, null);
+            if(!_game._medBotFollowTargets.ContainsKey(_id)) _game._medBotFollowTargets.Add(_id, null);
+
             //Radar Dot
             if (now - _tickLastRadarDot >= 900)
             {
@@ -573,7 +577,7 @@ namespace InfServer.Script.GameType_Multi
                     steering.steerDelegate = steerAlongPath;
             }
 
-            #endregion
         }
+        #endregion
     }
 }

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
@@ -38,6 +38,11 @@ namespace InfServer.Script.GameType_Multi
         public int _botDifficulty;   // 1-10 are valid entries, controls percentage of veteran spawns.
         public int _botDifficultyPlayerModifier;   // Used to increase difficulty of arena when over 6 players.
 
+        // 0 = no proper game end (no last game || insufficient players)
+        // 1 = timer hit zero
+        // 2 = captured all flags
+        public int _howLastGameEnded;
+
         #region Stat Recording
         private List<Team> activeTeams = null;
         #endregion
@@ -61,6 +66,8 @@ namespace InfServer.Script.GameType_Multi
 
             _team = _arena.getTeamByName("Titan Militia");
             _botTeam = _arena.getTeamByName("Collective Military");
+
+            _howLastGameEnded = 0; // no last game
 
             var arn = _arena._name.ToLower();
 
@@ -88,6 +95,7 @@ namespace InfServer.Script.GameType_Multi
             int playing = _arena.PlayerCount;
             if (_arena._bGameRunning && playing < _minPlayers && _arena._bIsPublic)
             {
+            	_howLastGameEnded = 0; // game end due to insufficient players (or everyone got specced)
                 _baseScript.bJackpot = false;
                 //Stop the game and reset voting
                 _arena.gameEnd();
@@ -108,8 +116,21 @@ namespace InfServer.Script.GameType_Multi
             //Do we have enough to start a game?
             if (!_arena._bGameRunning && _baseScript._tickGameStarting == 0 && playing >= _minPlayers && _arena._bIsPublic)
             {
+            	// give +20s time between rounds if there was a last game
+            	int extraTime = (_howLastGameEnded>0) ? 20 : 0;
+
+            	/*
+                if(_arena._name.Contains("]--")){
+            		_arena.sendArenaMessage(String.Format("TESTING MODE [HLGE={0}]", _howLastGameEnded));
+            		if(extraTime>5){
+            			_arena.sendArenaMessage("extraTime reduced to 5");
+            			extraTime = 5;
+            		}
+            	}
+                */
+
                 _baseScript._tickGameStarting = now;
-                _arena.setTicker(1, 3, _config.deathMatch.startDelay * 100, "Next game: ",
+                _arena.setTicker(1, 3, (_config.deathMatch.startDelay + extraTime) * 100, "Next game: ",
                     delegate ()
                     {   //Trigger the game start
                         _arena.gameStart();
@@ -134,6 +155,7 @@ namespace InfServer.Script.GameType_Multi
                 //Has anyone won?
                 if (team1count == 0 || team2count == 0)
                 {
+                	_howLastGameEnded = 2; // game end due to victory
                     _baseScript._winner = _team;
                     _arena.gameEnd();
                     return;
@@ -251,7 +273,11 @@ namespace InfServer.Script.GameType_Multi
 
             UpdateTickers();
 
+            // 30 min * 60 sec/min * 100 tick/sec
             int timer = 1800 * 100;
+
+            //game-end test syntax
+            //if(_arena._name.Contains("]--")) timer = 30 * 100; // 30 sec to speed it up
 
             if(!_arena._bLocked && _arena._name.ToLower().StartsWith("[1cc]")){
                 _arena._bLocked = true;
@@ -263,6 +289,7 @@ namespace InfServer.Script.GameType_Multi
             _arena.setTicker(1, 3, timer, "Time Left: ",
                 delegate ()
                 {   //Trigger game end
+                	_howLastGameEnded = 1; // game end due to timeout
                     _arena.gameEnd();
                 }
             );

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
@@ -198,6 +198,10 @@ namespace InfServer.Script.GameType_Multi
             _arena.flagReset();
             _arena.flagSpawn();
 
+            // wipe lists from last game
+            _medBotFollowTargets = new Dictionary<ushort, Player>();
+            _medBotHealTargets = new Dictionary<ushort, Player>();
+
             _firstRushWave = false;
             _secondRushWave = false;
             _thirdRushWave = false;

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Coop.cs
@@ -95,7 +95,7 @@ namespace InfServer.Script.GameType_Multi
             int playing = _arena.PlayerCount;
             if (_arena._bGameRunning && playing < _minPlayers && _arena._bIsPublic)
             {
-            	_howLastGameEnded = 0; // game end due to insufficient players (or everyone got specced)
+                _howLastGameEnded = 0; // game end due to insufficient players (or everyone got specced)
                 _baseScript.bJackpot = false;
                 //Stop the game and reset voting
                 _arena.gameEnd();
@@ -116,17 +116,17 @@ namespace InfServer.Script.GameType_Multi
             //Do we have enough to start a game?
             if (!_arena._bGameRunning && _baseScript._tickGameStarting == 0 && playing >= _minPlayers && _arena._bIsPublic)
             {
-            	// give +20s time between rounds if there was a last game
-            	int extraTime = (_howLastGameEnded>0) ? 20 : 0;
+                // give +20s time between rounds if there was a last game
+                int extraTime = (_howLastGameEnded>0) ? 20 : 0;
 
-            	/*
+                /*
                 if(_arena._name.Contains("]--")){
-            		_arena.sendArenaMessage(String.Format("TESTING MODE [HLGE={0}]", _howLastGameEnded));
-            		if(extraTime>5){
-            			_arena.sendArenaMessage("extraTime reduced to 5");
-            			extraTime = 5;
-            		}
-            	}
+                    _arena.sendArenaMessage(String.Format("TESTING MODE [HLGE={0}]", _howLastGameEnded));
+                    if(extraTime>5){
+                        _arena.sendArenaMessage("extraTime reduced to 5");
+                        extraTime = 5;
+                    }
+                }
                 */
 
                 _baseScript._tickGameStarting = now;
@@ -155,7 +155,7 @@ namespace InfServer.Script.GameType_Multi
                 //Has anyone won?
                 if (team1count == 0 || team2count == 0)
                 {
-                	_howLastGameEnded = 2; // game end due to victory
+                    _howLastGameEnded = 2; // game end due to victory
                     _baseScript._winner = _team;
                     _arena.gameEnd();
                     return;
@@ -293,7 +293,7 @@ namespace InfServer.Script.GameType_Multi
             _arena.setTicker(1, 3, timer, "Time Left: ",
                 delegate ()
                 {   //Trigger game end
-                	_howLastGameEnded = 1; // game end due to timeout
+                    _howLastGameEnded = 1; // game end due to timeout
                     _arena.gameEnd();
                 }
             );


### PR DESCRIPTION
- Time until next game increased to 30 seconds if previous round was a full play-through (victory or buzzer).
- Fixed the infamous medic no-follow bug: the medic bot will now continue to follow players when they continue into a subsequent game. No more rejoins necessary.