### PR TITLE
Io's Landing 231220 patch

### DIFF
--- a/Complete Zones/Ios Landing/assets/ioslanding.nws
+++ b/Complete Zones/Ios Landing/assets/ioslanding.nws
@@ -48,6 +48,13 @@ Skirmish Extreme combines the classic Skirmish feel with some great new features
 
 ~B~2Zone Updates~B
 
+[=~b~512/20/2023~2~B=]
+~b~4-C~2~B
+~4
+1. Nerfed rewards for Easy to incentivize Normal difficulty and up
+2. Adjusted cutoff time for kill credit: now starts at 3 minutes and increases to 4 (at 4/39) and 5 (at 6/39)
+
+
 [=~b~512/18/2023~2~B=]
 ~b~4-C~2~B
 ~4

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Spawn.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Coop/Spawn.cs
@@ -259,6 +259,8 @@ namespace InfServer.Script.GameType_Multi
 
                 case 4:
                     {
+                        _baseScript._lastCaptureCutoff = 4 * 60 * 1000;
+
                         if (!_sixthDifficultyWave)
                         {
                             _sixthDifficultyWave = true;
@@ -276,6 +278,8 @@ namespace InfServer.Script.GameType_Multi
 
                 case 6:
                     {
+                        _baseScript._lastCaptureCutoff = 5 * 60 * 1000;
+
                         if (!_secondLightExoWave)
                         {
                             _secondLightExoWave = true;

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Objects/CapturePoint.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Gametypes/Objects/CapturePoint.cs
@@ -163,6 +163,12 @@ namespace InfServer.Script.GameType_Multi
                             pointReward += 200 + (flags<11? 0: 200) + (flags<21? 0: 200) + (flags<31? 0: 400);
                         }
 
+                        if(_arena._name.ToLower().EndsWith(" easy")){
+                        	cashReward = Math.Max(200, cashReward / 10);
+                        	expReward = Math.Max(100, expReward / 10);
+                        	pointReward = 100;
+                        }
+
                     }
 
                     foreach (Player player in playersInArea.Where(p => p._team == flag.team))

--- a/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
+++ b/Complete Zones/Ios Landing/scripts/GameTypes/Multi/Main.cs
@@ -107,7 +107,7 @@ namespace InfServer.Script.GameType_Multi
 
 			if (_arena._name.ToLower().StartsWith("[co-op]") || _arena._name.ToLower().StartsWith("[1cc]")){
 				_gameType = Settings.GameTypes.Coop;
-				_lastCaptureCutoff = 5 * 60 * 1000;
+				_lastCaptureCutoff = 3 * 60 * 1000;
 			}
 			else if (_arena._name.ToLower().Equals("[pvp] royale"))
 				_gameType = Settings.GameTypes.Royale;


### PR DESCRIPTION
- Nerfed rewards for Easy to incentivize Normal difficulty and up
- Adjusted cutoff time for kill credit: now starts at 3 minutes and increases to 4 (at 4/39) and 5 (at 6/39)